### PR TITLE
fix missing content-server-pane if connectionStore have an empty clus…

### DIFF
--- a/frontend/src/AppContent.vue
+++ b/frontend/src/AppContent.vue
@@ -241,7 +241,12 @@ const onKeyShortcut = (e) => {
           >
             <connection-pane class="app-side flex-item-expand" />
           </resizeable-wrapper>
+          <content-server-pane
+            v-if="isEmpty(connectionStore.clusters)"
+            class="flex-item-expand"
+          />
           <content-pane
+            v-else
             v-for="t in tabStore.tabs"
             v-show="tabStore.currentTabName === t.name"
             :key="t.name"

--- a/frontend/src/components/content_value/ContentClusterStatus.vue
+++ b/frontend/src/components/content_value/ContentClusterStatus.vue
@@ -367,9 +367,9 @@ const clusterStatus = computed(() => {
 });
 
 const usedCPU = computed(() => {
+  return "fake";
   for (const cluster of clusterInfo.value) {
     if (cluster.name === tabStore.currentTabName) {
-      return ["fake", "fake"];
       console.log("matched: ", cluster);
       return get(cluster, "cpuCount", "fake");
     }


### PR DESCRIPTION
fix missing content-server-pane if connectionStore have an empty clusters

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved dynamic rendering of components based on the connection state, enhancing user experience by displaying appropriate content when clusters are available or absent.
  
- **Bug Fixes**
	- Updated the `usedCPU` property to return a single value instead of an array, ensuring more accurate representation of CPU usage in the cluster status display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->