### PR TITLE
change ci trigger condition (#21)

### DIFF
--- a/.github/workflows/release-linux.yaml
+++ b/.github/workflows/release-linux.yaml
@@ -9,6 +9,9 @@ on:
         description: 'Version tag'
         required: true
         default: '1.0.0'
+  push:
+    tags:
+      - "v*"
 
 jobs:
   release:

--- a/.github/workflows/release-windows.yaml
+++ b/.github/workflows/release-windows.yaml
@@ -13,9 +13,12 @@ on:
         required: true
         default: '1.0.0'
   push:
-    branches: [ main, master ]
-  pull_request:
-    branches: [ main, master ]
+    tags:
+      - "v*"
+  # push:
+  #   branches: [ main, master ]
+  # pull_request:
+  #   branches: [ main, master ]
 
 jobs:
   release:


### PR DESCRIPTION
change release trigger on windows and linux

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced release workflows for both Linux and Windows applications to support versioned tagging.
	- Introduced a required `tag` input for the Windows release workflow, defaulting to '1.0.0'.

- **Bug Fixes**
	- Streamlined the workflow triggers to focus on versioned releases for Windows.

- **Documentation**
	- Updated workflow configurations to clarify the new triggers and inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->