### PR TITLE
cli list don't refresh after cluster switched

### DIFF
--- a/frontend/src/components/content/ContentCliMgmt.vue
+++ b/frontend/src/components/content/ContentCliMgmt.vue
@@ -357,11 +357,15 @@ onUnmounted(() => {
 }
 );
 const refresh = async (cluster) => {
+  data.loading = true
+  sessionStore.emptyResults()
   const resp = await GetSessionsByClusterName(cluster)
   if (!resp.success) {
     console.log("get session by cluster name failed: ", resp.msg)
+    data.loading = false
     return
   }
+  data.loading = false
   sessionStore.setResults(resp.data)
   console.log("resp data is ", resp.data)
 };

--- a/frontend/src/stores/session.js
+++ b/frontend/src/stores/session.js
@@ -18,5 +18,8 @@ export const useSessionStore = defineStore('session', {
     addResult(newResult) {
       this.results.push(newResult);
     },
+    emptyResults() {
+      this.results = [];
+    }
   },
 });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced session management with improved loading states and error handling for CLI session deletion.
	- Added a method to clear previous session results before fetching new data.

- **Bug Fixes**
	- Implemented error handling during the deletion of CLI sessions.

- **Improvements**
	- Updated UI to reflect loading status for resource and namespace options dynamically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->